### PR TITLE
Allow docker image to be build on other architecture

### DIFF
--- a/Dockerfile.build_and_run
+++ b/Dockerfile.build_and_run
@@ -1,9 +1,23 @@
 # STAGE 1: Build the binary
-FROM mozilla/sbt AS builder
+FROM openjdk:11-jre AS builder
 
+ARG SBT_VERSION=1.6.2
+
+WORKDIR /app
+RUN \
+  mkdir /working/ && \
+  cd /working/ && \
+  curl -L -o sbt-$SBT_VERSION.deb https://repo.scala-sbt.org/scalasbt/debian/sbt-$SBT_VERSION.deb && \
+  dpkg -i sbt-$SBT_VERSION.deb && \
+  rm sbt-$SBT_VERSION.deb && \
+  apt-get update && \
+  apt-get install sbt && \
+  cd && \
+  rm -r /working/ && \
+  sbt sbtVersion
 WORKDIR /src
 COPY . .
-RUN apt-get update && apt-get install -y nodejs npm sbt
+RUN apt-get update && apt-get install -y nodejs npm openjdk-11-jdk-headless
 RUN sbt -mem 2048 dist
 RUN mkdir dist
 RUN cd dist && unzip /src/app/jvm/target/universal/*.zip

--- a/Dockerfile.build_and_run
+++ b/Dockerfile.build_and_run
@@ -1,5 +1,5 @@
 # STAGE 1: Build the binary
-FROM openjdk:11-jre AS builder
+FROM openjdk:11-jdk AS builder
 
 ARG SBT_VERSION=1.6.2
 
@@ -17,7 +17,7 @@ RUN \
   sbt sbtVersion
 WORKDIR /src
 COPY . .
-RUN apt-get update && apt-get install -y nodejs npm openjdk-11-jdk-headless
+RUN apt-get update && apt-get install -y nodejs npm
 RUN sbt -mem 2048 dist
 RUN mkdir dist
 RUN cd dist && unzip /src/app/jvm/target/universal/*.zip

--- a/Dockerfile.build_and_run
+++ b/Dockerfile.build_and_run
@@ -1,9 +1,9 @@
 # STAGE 1: Build the binary
-FROM openlaw/scala-builder:node AS builder
+FROM mozilla/sbt AS builder
 
 WORKDIR /src
 COPY . .
-RUN apk add --update nodejs npm
+RUN apt-get update && apt-get install -y nodejs npm sbt
 RUN sbt -mem 2048 dist
 RUN mkdir dist
 RUN cd dist && unzip /src/app/jvm/target/universal/*.zip

--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -1,4 +1,4 @@
-FROM openlaw/scala-builder:node AS builder
+FROM mozilla/sbt AS builder
 
 WORKDIR /src
-RUN apk add --update nodejs npm
+RUN apt-get update && apt-get install -y nodejs npm sbt

--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -1,4 +1,20 @@
-FROM mozilla/sbt AS builder
+# STAGE 1: Build the binary
+FROM openjdk:11-jre AS builder
 
+ARG SBT_VERSION=1.6.2
+
+WORKDIR /app
+RUN \
+  mkdir /working/ && \
+  cd /working/ && \
+  curl -L -o sbt-$SBT_VERSION.deb https://repo.scala-sbt.org/scalasbt/debian/sbt-$SBT_VERSION.deb && \
+  dpkg -i sbt-$SBT_VERSION.deb && \
+  rm sbt-$SBT_VERSION.deb && \
+  apt-get update && \
+  apt-get install sbt && \
+  cd && \
+  rm -r /working/ && \
+  sbt sbtVersion
 WORKDIR /src
-RUN apt-get update && apt-get install -y nodejs npm sbt
+RUN apt-get update && apt-get install -y nodejs npm openjdk-11-jdk-headless
+


### PR DESCRIPTION
needed to build quizmaster on aarch64 but openlaw/scala-builder:node did not have the corresponding image built.
Took inspiration from https://github.com/mozilla/docker-sbt to build upon openjdk:11-jre which is compiled for both amd64 and aarch64.

Tested on amd64 and aarch64 and image was built correctly and fully functionnal